### PR TITLE
Remove unneeded buffer

### DIFF
--- a/common.h
+++ b/common.h
@@ -58,7 +58,6 @@ typedef struct {
     half* x; // activation at current time stamp (dim,)
     half* xb; // same, but inside a residual branch (dim,)
     half* hb; // buffer for hidden dimension in the ffn (hidden_dim,)
-    half* hb2; // buffer for hidden dimension in the ffn (hidden_dim,)
     half* q; // query (dim,)
     half* att; // buffer for scores/attention values (n_heads, seq_len)
     half* logits; // output logits

--- a/llama2_q4.cu
+++ b/llama2_q4.cu
@@ -40,7 +40,6 @@ void malloc_run_state(RunState* s, Config* p, bool allocLogitsArray) {
     cudaMalloc((void**)&s->x, p->dim * sizeof(half));
     cudaMalloc((void**)&s->xb, p->dim * sizeof(half));
     cudaMalloc((void**)&s->hb, p->hidden_dim * sizeof(half));
-    cudaMalloc((void**)&s->hb2, p->hidden_dim * sizeof(half));
     cudaMalloc((void**)&s->q, p->dim * sizeof(half));
     cudaMalloc((void**)&s->att, p->n_heads * p->dim * sizeof(half));
     cudaMalloc((void**)&s->logits, p->vocab_size * sizeof(half));
@@ -51,7 +50,7 @@ void malloc_run_state(RunState* s, Config* p, bool allocLogitsArray) {
     cudaMallocHost((void**)&s->shared_data, sizeof(SharedData));
 
     // ensure all mallocs went fine
-    if (!s->x || !s->xb || !s->pos || !s->hb || !s->hb2 || !s->q
+    if (!s->x || !s->xb || !s->pos || !s->hb || !s->q
         || !s->att || !s->logits || !s->key_cache
         || !s->value_cache || !s->shared_data) {
         printf("malloc failed for allocaing run state!\n");
@@ -72,7 +71,6 @@ void free_run_state(RunState* s) {
     cudaFree(s->xb);
     cudaFree(s->pos);
     cudaFree(s->hb);
-    cudaFree(s->hb2);
     cudaFree(s->q);
     cudaFree(s->att);
     cudaFree(s->logits);


### PR DESCRIPTION
`hb2` buffer isn't used because the residual connection is fused into the mat_vec_int4 kernel.